### PR TITLE
Event Application Status

### DIFF
--- a/docs/DATABASE.md
+++ b/docs/DATABASE.md
@@ -334,6 +334,10 @@ erDiagram
     application_statuses {
         serial id PK
         varchar label
+        varchar title
+        varchar description
+        varchar variant
+        boolean is_final
     }
 
     rsvp_statuses {
@@ -374,7 +378,7 @@ erDiagram
 - The diagram shows **base tables** only. Entities prefixed with `authz_` (e.g. `authz_permission`, `authz_role`, `authz_user_role`) are in the `authz` schema; all others are in `public`.
 - The database also has two **views** (not shown): `application_view` and `application_form_view`. They are denormalized views over `event_applications`, `user_profiles`, and lookup tables. See [ARCHITECTURE.md](./ARCHITECTURE.md) under "Database Views" for details.
 - The `heard_from_sources` lookup table has no foreign keys from other tables in the current schema.
-- `application_statuses` (labels: pending_review, approved, denied, waitlisted) is referenced by `event_applications.status_id`. `rsvp_statuses` (labels: pending, accepted, declined, timed_out) is referenced by `event_rsvp_responses.status_id`.
+- `application_statuses` (labels: pending_review, approved, denied, waitlisted) is referenced by `event_applications.status_id`. Unlike the other lookup tables, it also carries the UI display config for each status: `title`, `description`, `variant` (badge style), and `is_final` (whether the decision is final). These columns are read on the server via `getApplicationStatusDisplayMap()` in `src/app/dashboard/events/application-status.ts` and seeded from `applicationStatusDisplayList` in `src/types/lookups.ts`. `rsvp_statuses` (labels: pending, accepted, declined, timed_out) is referenced by `event_rsvp_responses.status_id`.
 - `event_types` (labels: meal, workshop, hackathon) is referenced by `events.event_type_id`. Meals and workshops are typically child events (`parent_event_id` set to the main event). `check_ins` records one row per user per event (main event = door check-in; child event = e.g. meal check-in).
 
 ## Drizzle Studio

--- a/drizzle/0009_fine_silver_samurai.sql
+++ b/drizzle/0009_fine_silver_samurai.sql
@@ -1,0 +1,4 @@
+ALTER TABLE "application_statuses" ADD COLUMN "title" varchar(100) NOT NULL;--> statement-breakpoint
+ALTER TABLE "application_statuses" ADD COLUMN "description" varchar(500) NOT NULL;--> statement-breakpoint
+ALTER TABLE "application_statuses" ADD COLUMN "variant" varchar(20) NOT NULL;--> statement-breakpoint
+ALTER TABLE "application_statuses" ADD COLUMN "is_final" boolean NOT NULL;

--- a/drizzle/meta/0009_snapshot.json
+++ b/drizzle/meta/0009_snapshot.json
@@ -1,0 +1,2388 @@
+{
+  "id": "6fa48f25-2646-4f68-aa02-1fe1fe9ca1d7",
+  "prevId": "18c792bc-2dfd-44c7-b7d1-0fb035cefefb",
+  "version": "7",
+  "dialect": "postgresql",
+  "tables": {
+    "public.account": {
+      "name": "account",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "account_id": {
+          "name": "account_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "provider_id": {
+          "name": "provider_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "access_token": {
+          "name": "access_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "refresh_token": {
+          "name": "refresh_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "id_token": {
+          "name": "id_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "scope": {
+          "name": "scope",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "password": {
+          "name": "password",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "access_token_expires_at": {
+          "name": "access_token_expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "refresh_token_expires_at": {
+          "name": "refresh_token_expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "account_user_id_user_id_fk": {
+          "name": "account_user_id_user_id_fk",
+          "tableFrom": "account",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.session": {
+      "name": "session",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "token": {
+          "name": "token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "ip_address": {
+          "name": "ip_address",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "user_agent": {
+          "name": "user_agent",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "session_user_id_user_id_fk": {
+          "name": "session_user_id_user_id_fk",
+          "tableFrom": "session",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "session_token_unique": {
+          "name": "session_token_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "token"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.user": {
+      "name": "user",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "email": {
+          "name": "email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "email_verified": {
+          "name": "email_verified",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "image": {
+          "name": "image",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "user_email_unique": {
+          "name": "user_email_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "email"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.verification": {
+      "name": "verification",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "identifier": {
+          "name": "identifier",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "value": {
+          "name": "value",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.check_ins": {
+      "name": "check_ins",
+      "schema": "",
+      "columns": {
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "event_id": {
+          "name": "event_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "checked_in_at": {
+          "name": "checked_in_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "check_ins_user_id_event_id_unique": {
+          "name": "check_ins_user_id_event_id_unique",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "event_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_check_ins_event_id_checked_in_at": {
+          "name": "idx_check_ins_event_id_checked_in_at",
+          "columns": [
+            {
+              "expression": "event_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "checked_in_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_check_ins_user_id": {
+          "name": "idx_check_ins_user_id",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "check_ins_user_id_user_id_fk": {
+          "name": "check_ins_user_id_user_id_fk",
+          "tableFrom": "check_ins",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "check_ins_event_id_events_id_fk": {
+          "name": "check_ins_event_id_events_id_fk",
+          "tableFrom": "check_ins",
+          "tableTo": "events",
+          "columnsFrom": [
+            "event_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.event_applications": {
+      "name": "event_applications",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "event_id": {
+          "name": "event_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status_id": {
+          "name": "status_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "reviewed_at": {
+          "name": "reviewed_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "reviewed_by": {
+          "name": "reviewed_by",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "waitlist_position": {
+          "name": "waitlist_position",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "responses": {
+          "name": "responses",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "event_applications_event_id_user_id_unique": {
+          "name": "event_applications_event_id_user_id_unique",
+          "columns": [
+            {
+              "expression": "event_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_event_applications_event_id_created_at": {
+          "name": "idx_event_applications_event_id_created_at",
+          "columns": [
+            {
+              "expression": "event_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": false,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_event_applications_user_id": {
+          "name": "idx_event_applications_user_id",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "event_applications_event_id_events_id_fk": {
+          "name": "event_applications_event_id_events_id_fk",
+          "tableFrom": "event_applications",
+          "tableTo": "events",
+          "columnsFrom": [
+            "event_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "event_applications_user_id_user_id_fk": {
+          "name": "event_applications_user_id_user_id_fk",
+          "tableFrom": "event_applications",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "event_applications_status_id_application_statuses_id_fk": {
+          "name": "event_applications_status_id_application_statuses_id_fk",
+          "tableFrom": "event_applications",
+          "tableTo": "application_statuses",
+          "columnsFrom": [
+            "status_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "event_applications_reviewed_by_user_id_fk": {
+          "name": "event_applications_reviewed_by_user_id_fk",
+          "tableFrom": "event_applications",
+          "tableTo": "user",
+          "columnsFrom": [
+            "reviewed_by"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.event_attendees": {
+      "name": "event_attendees",
+      "schema": "",
+      "columns": {
+        "event_id": {
+          "name": "event_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "registered_at": {
+          "name": "registered_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "event_attendees_event_id_events_id_fk": {
+          "name": "event_attendees_event_id_events_id_fk",
+          "tableFrom": "event_attendees",
+          "tableTo": "events",
+          "columnsFrom": [
+            "event_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "event_attendees_user_id_user_id_fk": {
+          "name": "event_attendees_user_id_user_id_fk",
+          "tableFrom": "event_attendees",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "event_attendees_event_id_user_id_pk": {
+          "name": "event_attendees_event_id_user_id_pk",
+          "columns": [
+            "event_id",
+            "user_id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.event_interest_registrations": {
+      "name": "event_interest_registrations",
+      "schema": "",
+      "columns": {
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "event_id": {
+          "name": "event_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "event_interest_registrations_user_id_event_id_unique": {
+          "name": "event_interest_registrations_user_id_event_id_unique",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "event_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "event_interest_registrations_user_id_user_id_fk": {
+          "name": "event_interest_registrations_user_id_user_id_fk",
+          "tableFrom": "event_interest_registrations",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "event_interest_registrations_event_id_events_id_fk": {
+          "name": "event_interest_registrations_event_id_events_id_fk",
+          "tableFrom": "event_interest_registrations",
+          "tableTo": "events",
+          "columnsFrom": [
+            "event_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.event_rsvp_responses": {
+      "name": "event_rsvp_responses",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "rsvp_wave_id": {
+          "name": "rsvp_wave_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status_id": {
+          "name": "status_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "responded_at": {
+          "name": "responded_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "event_rsvp_responses_rsvp_wave_id_user_id_unique": {
+          "name": "event_rsvp_responses_rsvp_wave_id_user_id_unique",
+          "columns": [
+            {
+              "expression": "rsvp_wave_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "event_rsvp_responses_rsvp_wave_id_event_rsvp_waves_id_fk": {
+          "name": "event_rsvp_responses_rsvp_wave_id_event_rsvp_waves_id_fk",
+          "tableFrom": "event_rsvp_responses",
+          "tableTo": "event_rsvp_waves",
+          "columnsFrom": [
+            "rsvp_wave_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "event_rsvp_responses_user_id_user_id_fk": {
+          "name": "event_rsvp_responses_user_id_user_id_fk",
+          "tableFrom": "event_rsvp_responses",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "event_rsvp_responses_status_id_rsvp_statuses_id_fk": {
+          "name": "event_rsvp_responses_status_id_rsvp_statuses_id_fk",
+          "tableFrom": "event_rsvp_responses",
+          "tableTo": "rsvp_statuses",
+          "columnsFrom": [
+            "status_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.event_rsvp_waves": {
+      "name": "event_rsvp_waves",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "event_id": {
+          "name": "event_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "wave": {
+          "name": "wave",
+          "type": "smallint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "respond_by": {
+          "name": "respond_by",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "event_rsvp_waves_event_id_wave_unique": {
+          "name": "event_rsvp_waves_event_id_wave_unique",
+          "columns": [
+            {
+              "expression": "event_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "wave",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "event_rsvp_waves_event_id_events_id_fk": {
+          "name": "event_rsvp_waves_event_id_events_id_fk",
+          "tableFrom": "event_rsvp_waves",
+          "tableTo": "events",
+          "columnsFrom": [
+            "event_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.events": {
+      "name": "events",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "parent_event_id": {
+          "name": "parent_event_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "event_type_id": {
+          "name": "event_type_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "has_application": {
+          "name": "has_application",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "application_questions": {
+          "name": "application_questions",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "starts_at": {
+          "name": "starts_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "ends_at": {
+          "name": "ends_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "capacity": {
+          "name": "capacity",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_events_has_application": {
+          "name": "idx_events_has_application",
+          "columns": [
+            {
+              "expression": "has_application",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "events_parent_event_id_events_id_fk": {
+          "name": "events_parent_event_id_events_id_fk",
+          "tableFrom": "events",
+          "tableTo": "events",
+          "columnsFrom": [
+            "parent_event_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "events_event_type_id_event_types_id_fk": {
+          "name": "events_event_type_id_event_types_id_fk",
+          "tableFrom": "events",
+          "tableTo": "event_types",
+          "columnsFrom": [
+            "event_type_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.group_members": {
+      "name": "group_members",
+      "schema": "",
+      "columns": {
+        "group_id": {
+          "name": "group_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "group_members_group_id_groups_id_fk": {
+          "name": "group_members_group_id_groups_id_fk",
+          "tableFrom": "group_members",
+          "tableTo": "groups",
+          "columnsFrom": [
+            "group_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "group_members_user_id_user_id_fk": {
+          "name": "group_members_user_id_user_id_fk",
+          "tableFrom": "group_members",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "group_members_group_id_user_id_pk": {
+          "name": "group_members_group_id_user_id_pk",
+          "columns": [
+            "group_id",
+            "user_id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.groups": {
+      "name": "groups",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "event_id": {
+          "name": "event_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "groups_event_id_events_id_fk": {
+          "name": "groups_event_id_events_id_fk",
+          "tableFrom": "groups",
+          "tableTo": "events",
+          "columnsFrom": [
+            "event_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.submissions": {
+      "name": "submissions",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "group_id": {
+          "name": "group_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "event_id": {
+          "name": "event_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "submitted_at": {
+          "name": "submitted_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "submissions_group_id_event_id_unique": {
+          "name": "submissions_group_id_event_id_unique",
+          "columns": [
+            {
+              "expression": "group_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "event_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "submissions_group_id_groups_id_fk": {
+          "name": "submissions_group_id_groups_id_fk",
+          "tableFrom": "submissions",
+          "tableTo": "groups",
+          "columnsFrom": [
+            "group_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "submissions_event_id_events_id_fk": {
+          "name": "submissions_event_id_events_id_fk",
+          "tableFrom": "submissions",
+          "tableTo": "events",
+          "columnsFrom": [
+            "event_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.user_dietary_restrictions": {
+      "name": "user_dietary_restrictions",
+      "schema": "",
+      "columns": {
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "restriction_id": {
+          "name": "restriction_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "user_dietary_restrictions_user_id_restriction_id_unique": {
+          "name": "user_dietary_restrictions_user_id_restriction_id_unique",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "restriction_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "user_dietary_restrictions_user_id_user_id_fk": {
+          "name": "user_dietary_restrictions_user_id_user_id_fk",
+          "tableFrom": "user_dietary_restrictions",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "user_dietary_restrictions_restriction_id_dietary_restrictions_id_fk": {
+          "name": "user_dietary_restrictions_restriction_id_dietary_restrictions_id_fk",
+          "tableFrom": "user_dietary_restrictions",
+          "tableTo": "dietary_restrictions",
+          "columnsFrom": [
+            "restriction_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.user_interests": {
+      "name": "user_interests",
+      "schema": "",
+      "columns": {
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "interest_id": {
+          "name": "interest_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "user_interests_user_id_interest_id_unique": {
+          "name": "user_interests_user_id_interest_id_unique",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "interest_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "user_interests_user_id_user_id_fk": {
+          "name": "user_interests_user_id_user_id_fk",
+          "tableFrom": "user_interests",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "user_interests_interest_id_interests_id_fk": {
+          "name": "user_interests_interest_id_interests_id_fk",
+          "tableFrom": "user_interests",
+          "tableTo": "interests",
+          "columnsFrom": [
+            "interest_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.user_profiles": {
+      "name": "user_profiles",
+      "schema": "",
+      "columns": {
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "full_name": {
+          "name": "full_name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "gender_id": {
+          "name": "gender_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "university_id": {
+          "name": "university_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "major_id": {
+          "name": "major_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "year_of_study_id": {
+          "name": "year_of_study_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "user_profiles_user_id_user_id_fk": {
+          "name": "user_profiles_user_id_user_id_fk",
+          "tableFrom": "user_profiles",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "user_profiles_gender_id_genders_id_fk": {
+          "name": "user_profiles_gender_id_genders_id_fk",
+          "tableFrom": "user_profiles",
+          "tableTo": "genders",
+          "columnsFrom": [
+            "gender_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "user_profiles_university_id_universities_id_fk": {
+          "name": "user_profiles_university_id_universities_id_fk",
+          "tableFrom": "user_profiles",
+          "tableTo": "universities",
+          "columnsFrom": [
+            "university_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "user_profiles_major_id_majors_id_fk": {
+          "name": "user_profiles_major_id_majors_id_fk",
+          "tableFrom": "user_profiles",
+          "tableTo": "majors",
+          "columnsFrom": [
+            "major_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "user_profiles_year_of_study_id_years_of_study_id_fk": {
+          "name": "user_profiles_year_of_study_id_years_of_study_id_fk",
+          "tableFrom": "user_profiles",
+          "tableTo": "years_of_study",
+          "columnsFrom": [
+            "year_of_study_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.application_statuses": {
+      "name": "application_statuses",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "label": {
+          "name": "label",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "title": {
+          "name": "title",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "varchar(500)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "variant": {
+          "name": "variant",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "is_final": {
+          "name": "is_final",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "application_statuses_label_unique": {
+          "name": "application_statuses_label_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "label"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.dietary_restrictions": {
+      "name": "dietary_restrictions",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "label": {
+          "name": "label",
+          "type": "varchar(150)",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "dietary_restrictions_label_unique": {
+          "name": "dietary_restrictions_label_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "label"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.event_types": {
+      "name": "event_types",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "label": {
+          "name": "label",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "event_types_label_unique": {
+          "name": "event_types_label_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "label"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.genders": {
+      "name": "genders",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "label": {
+          "name": "label",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "genders_label_unique": {
+          "name": "genders_label_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "label"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.heard_from_sources": {
+      "name": "heard_from_sources",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "label": {
+          "name": "label",
+          "type": "varchar(150)",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "heard_from_sources_label_unique": {
+          "name": "heard_from_sources_label_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "label"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.interests": {
+      "name": "interests",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "label": {
+          "name": "label",
+          "type": "varchar(150)",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "interests_label_unique": {
+          "name": "interests_label_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "label"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.majors": {
+      "name": "majors",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "label": {
+          "name": "label",
+          "type": "varchar(150)",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "majors_label_unique": {
+          "name": "majors_label_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "label"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.rsvp_statuses": {
+      "name": "rsvp_statuses",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "label": {
+          "name": "label",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "rsvp_statuses_label_unique": {
+          "name": "rsvp_statuses_label_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "label"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.universities": {
+      "name": "universities",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "label": {
+          "name": "label",
+          "type": "varchar(200)",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "universities_label_unique": {
+          "name": "universities_label_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "label"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.years_of_study": {
+      "name": "years_of_study",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "label": {
+          "name": "label",
+          "type": "varchar(10)",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "years_of_study_label_unique": {
+          "name": "years_of_study_label_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "label"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "authz.permission": {
+      "name": "permission",
+      "schema": "authz",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "slug": {
+          "name": "slug",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "permission_slug_unique": {
+          "name": "permission_slug_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "slug"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {
+        "lower_slug": {
+          "name": "lower_slug",
+          "value": "\"authz\".\"permission\".\"slug\" = lower(\"authz\".\"permission\".\"slug\")"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "authz.role": {
+      "name": "role",
+      "schema": "authz",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "slug": {
+          "name": "slug",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "role_slug_unique": {
+          "name": "role_slug_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "slug"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {
+        "lower_slug": {
+          "name": "lower_slug",
+          "value": "\"authz\".\"role\".\"slug\" = lower(\"authz\".\"role\".\"slug\")"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "authz.role_permission": {
+      "name": "role_permission",
+      "schema": "authz",
+      "columns": {
+        "role_id": {
+          "name": "role_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "permission_id": {
+          "name": "permission_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "role_permission_role_id_role_id_fk": {
+          "name": "role_permission_role_id_role_id_fk",
+          "tableFrom": "role_permission",
+          "tableTo": "role",
+          "schemaTo": "authz",
+          "columnsFrom": [
+            "role_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "role_permission_permission_id_permission_id_fk": {
+          "name": "role_permission_permission_id_permission_id_fk",
+          "tableFrom": "role_permission",
+          "tableTo": "permission",
+          "schemaTo": "authz",
+          "columnsFrom": [
+            "permission_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "role_permission_role_id_permission_id_pk": {
+          "name": "role_permission_role_id_permission_id_pk",
+          "columns": [
+            "role_id",
+            "permission_id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "authz.user_permission": {
+      "name": "user_permission",
+      "schema": "authz",
+      "columns": {
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "permission_id": {
+          "name": "permission_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "user_permission_user_id_user_id_fk": {
+          "name": "user_permission_user_id_user_id_fk",
+          "tableFrom": "user_permission",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "user_permission_permission_id_permission_id_fk": {
+          "name": "user_permission_permission_id_permission_id_fk",
+          "tableFrom": "user_permission",
+          "tableTo": "permission",
+          "schemaTo": "authz",
+          "columnsFrom": [
+            "permission_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "user_permission_user_id_permission_id_pk": {
+          "name": "user_permission_user_id_permission_id_pk",
+          "columns": [
+            "user_id",
+            "permission_id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "authz.user_role": {
+      "name": "user_role",
+      "schema": "authz",
+      "columns": {
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "role_id": {
+          "name": "role_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "user_role_user_id_user_id_fk": {
+          "name": "user_role_user_id_user_id_fk",
+          "tableFrom": "user_role",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "user_role_role_id_role_id_fk": {
+          "name": "user_role_role_id_role_id_fk",
+          "tableFrom": "user_role",
+          "tableTo": "role",
+          "schemaTo": "authz",
+          "columnsFrom": [
+            "role_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "user_role_user_id_role_id_pk": {
+          "name": "user_role_user_id_role_id_pk",
+          "columns": [
+            "user_id",
+            "role_id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    }
+  },
+  "enums": {},
+  "schemas": {
+    "authz": "authz"
+  },
+  "sequences": {},
+  "roles": {},
+  "policies": {},
+  "views": {
+    "public.application_form_view": {
+      "columns": {
+        "event_id": {
+          "name": "event_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "full_name": {
+          "name": "full_name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "gender_id": {
+          "name": "gender_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "university_id": {
+          "name": "university_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "major_id": {
+          "name": "major_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "year_of_study_id": {
+          "name": "year_of_study_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "interests": {
+          "name": "interests",
+          "type": "integer[]",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "dietary_restrictions": {
+          "name": "dietary_restrictions",
+          "type": "integer[]",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "responses": {
+          "name": "responses",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "definition": "\nWITH\n  interests_agg AS (\n    SELECT\n      user_id,\n      array_agg(DISTINCT interest_id) AS interests\n    FROM user_interests\n    WHERE interest_id IS NOT NULL\n    GROUP BY user_id\n  ),\n  dietary_agg AS (\n    SELECT\n      user_id,\n      array_agg(DISTINCT restriction_id) AS dietary_restrictions\n    FROM user_dietary_restrictions\n    WHERE restriction_id IS NOT NULL\n    GROUP BY user_id\n  )\nSELECT\n  a.event_id,\n  a.user_id,\n  p.full_name,\n  p.gender_id,\n  p.university_id,\n  p.major_id,\n  p.year_of_study_id,\n  COALESCE(i.interests, '{}'::integer[]) AS interests,\n  COALESCE(d.dietary_restrictions, '{}'::integer[]) AS dietary_restrictions,\n  a.responses,\n  a.created_at\nFROM event_applications a\nJOIN user_profiles p ON p.user_id = a.user_id\nLEFT JOIN interests_agg i ON i.user_id = a.user_id\nLEFT JOIN dietary_agg d ON d.user_id = a.user_id\n",
+      "name": "application_form_view",
+      "schema": "public",
+      "isExisting": false,
+      "materialized": false
+    },
+    "public.application_view": {
+      "columns": {
+        "event_id": {
+          "name": "event_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "event_name": {
+          "name": "event_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "email": {
+          "name": "email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "full_name": {
+          "name": "full_name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "gender": {
+          "name": "gender",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "university": {
+          "name": "university",
+          "type": "varchar(200)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "major": {
+          "name": "major",
+          "type": "varchar(150)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "year_of_study": {
+          "name": "year_of_study",
+          "type": "varchar(10)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "interests": {
+          "name": "interests",
+          "type": "text[]",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "dietary_restrictions": {
+          "name": "dietary_restrictions",
+          "type": "text[]",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "responses": {
+          "name": "responses",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "definition": "\nWITH\n  dr AS (\n    SELECT\n      u.user_id,\n      ARRAY_AGG(l.label ORDER BY l.label) AS dietary_restrictions\n    FROM user_dietary_restrictions u\n    JOIN dietary_restrictions l ON l.id = u.restriction_id\n    GROUP BY u.user_id\n  ),\n  ints AS (\n    SELECT\n      u.user_id,\n      ARRAY_AGG(l.label ORDER BY l.label) AS interests\n    FROM user_interests u\n    JOIN interests l ON l.id = u.interest_id\n    GROUP BY u.user_id\n  )\nSELECT\n  a.event_id,\n  e.name AS event_name,\n  a.user_id,\n  u.email,\n  p.full_name,\n  g.label AS gender,\n  un.label AS university,\n  m.label AS major,\n  y.label AS year_of_study,\n  ints.interests,\n  dr.dietary_restrictions,\n  a.responses,\n  a.created_at\nFROM event_applications a\nJOIN events e ON e.id = a.event_id\nJOIN \"user\" u ON u.id = a.user_id\nLEFT JOIN user_profiles p ON p.user_id = a.user_id\nLEFT JOIN genders g ON g.id = p.gender_id\nLEFT JOIN universities un ON un.id = p.university_id\nLEFT JOIN majors m ON m.id = p.major_id\nLEFT JOIN years_of_study y ON y.id = p.year_of_study_id\nLEFT JOIN ints ON ints.user_id = a.user_id\nLEFT JOIN dr ON dr.user_id = a.user_id\n",
+      "name": "application_view",
+      "schema": "public",
+      "isExisting": false,
+      "materialized": false
+    }
+  },
+  "_meta": {
+    "columns": {},
+    "schemas": {},
+    "tables": {}
+  }
+}

--- a/drizzle/meta/_journal.json
+++ b/drizzle/meta/_journal.json
@@ -64,6 +64,13 @@
       "when": 1775883902186,
       "tag": "0008_funny_human_robot",
       "breakpoints": true
+    },
+    {
+      "idx": 9,
+      "version": "7",
+      "when": 1780154069038,
+      "tag": "0009_fine_silver_samurai",
+      "breakpoints": true
     }
   ]
 }

--- a/scripts/seed-static.ts
+++ b/scripts/seed-static.ts
@@ -21,6 +21,7 @@ import {
   dietaryRestrictionsList,
   heardFromSourcesList,
   applicationStatusesList,
+  applicationStatusDisplayList,
   rsvpStatusesList,
   eventTypesList,
 } from '@/types/lookups';
@@ -45,6 +46,22 @@ function defineSeedTable<TTable extends Table>(
   };
 }
 
+function defineApplicationStatusSeedTable(): SeedTable<
+  typeof applicationStatuses
+> {
+  return {
+    table: applicationStatuses,
+    validLabels: applicationStatusesList as readonly string[],
+    values: applicationStatusDisplayList.map((s) => ({
+      label: s.label,
+      title: s.title,
+      description: s.description,
+      variant: s.variant,
+      isFinal: s.isFinal,
+    })),
+  };
+}
+
 // ---------- Table registry ----------
 const tables = [
   defineSeedTable(genders, gendersList),
@@ -54,7 +71,7 @@ const tables = [
   defineSeedTable(interests, interestsList),
   defineSeedTable(dietaryRestrictions, dietaryRestrictionsList),
   defineSeedTable(heardFromSources, heardFromSourcesList),
-  defineSeedTable(applicationStatuses, applicationStatusesList),
+  defineApplicationStatusSeedTable(),
   defineSeedTable(rsvpStatuses, rsvpStatusesList),
   defineSeedTable(eventTypes, eventTypesList),
 ] satisfies SeedTable<Table>[];

--- a/src/app/dashboard/events/ApplicationStatusBanner.tsx
+++ b/src/app/dashboard/events/ApplicationStatusBanner.tsx
@@ -10,8 +10,6 @@ import type { ApplicationStatusForUser } from '@/app/dashboard/events/actions';
 import {
   APPLICATION_TIMELINE_FIELDS,
   APPLICATION_TIMELINE_LABELS,
-  getApplicationStatusDisplay,
-  getApplicationStatusLabel,
 } from '@/app/dashboard/events/application-status';
 
 function formatDate(d: Date | null) {
@@ -33,9 +31,8 @@ export function ApplicationStatusBanner({
   application,
   standalone = false,
 }: Props) {
-  const { statusKey, createdAt, reviewedAt } = application;
-  const display = getApplicationStatusDisplay(statusKey);
-  const label = getApplicationStatusLabel(statusKey);
+  const { statusDisplay: display, createdAt, reviewedAt } = application;
+  const label = display.title;
   const timelineSource = { createdAt, reviewedAt };
   const submitted = formatDate(createdAt);
 

--- a/src/app/dashboard/events/ApplicationStatusBanner.tsx
+++ b/src/app/dashboard/events/ApplicationStatusBanner.tsx
@@ -6,8 +6,8 @@ import {
   CardHeader,
   CardTitle,
 } from '@/components/ui/card';
+import type { ApplicationStatusForUser } from '@/app/dashboard/events/actions';
 import {
-  type ApplicationStatusLabel,
   APPLICATION_TIMELINE_FIELDS,
   APPLICATION_TIMELINE_LABELS,
   getApplicationStatusDisplay,
@@ -23,26 +23,17 @@ function formatDate(d: Date | null) {
 }
 
 type Props = {
-  /** Application review status (e.g. pending_review, approved). */
-  statusKey: ApplicationStatusLabel;
-  /** Waitlist position, if waitlisted. */
-  waitlistPosition: number | null;
-  /** When the application was submitted. */
-  createdAt: Date;
-  /** When a decision was made. Null while pending. */
-  reviewedAt: Date | null;
+  application: ApplicationStatusForUser;
   /** Full card layout vs compact banner above the form. */
   standalone?: boolean;
 };
 
 /** Application status badge and timeline for the current user. */
 export function ApplicationStatusBanner({
-  statusKey,
-  waitlistPosition,
-  createdAt,
-  reviewedAt,
+  application,
   standalone = false,
 }: Props) {
+  const { statusKey, waitlistPosition, createdAt, reviewedAt } = application;
   const display = getApplicationStatusDisplay(statusKey);
   const label = getApplicationStatusLabel(statusKey, waitlistPosition);
   const timelineSource = { createdAt, reviewedAt };

--- a/src/app/dashboard/events/ApplicationStatusBanner.tsx
+++ b/src/app/dashboard/events/ApplicationStatusBanner.tsx
@@ -8,6 +8,8 @@ import {
 } from '@/components/ui/card';
 import {
   type ApplicationStatusLabel,
+  APPLICATION_TIMELINE_FIELDS,
+  APPLICATION_TIMELINE_LABELS,
   getApplicationStatusDisplay,
   getApplicationStatusLabel,
 } from '@/app/dashboard/events/application-status';
@@ -21,13 +23,19 @@ function formatDate(d: Date | null) {
 }
 
 type Props = {
-  statusKey: ApplicationStatusLabel | null;
+  /** Application review status (e.g. pending_review, approved). */
+  statusKey: ApplicationStatusLabel;
+  /** Waitlist position, if waitlisted. */
   waitlistPosition: number | null;
+  /** When the application was submitted. */
   createdAt: Date;
+  /** When a decision was made. Null while pending. */
   reviewedAt: Date | null;
+  /** Full card layout vs compact banner above the form. */
   standalone?: boolean;
 };
 
+/** Application status badge and timeline for the current user. */
 export function ApplicationStatusBanner({
   statusKey,
   waitlistPosition,
@@ -37,8 +45,8 @@ export function ApplicationStatusBanner({
 }: Props) {
   const display = getApplicationStatusDisplay(statusKey);
   const label = getApplicationStatusLabel(statusKey, waitlistPosition);
+  const timelineSource = { createdAt, reviewedAt };
   const submitted = formatDate(createdAt);
-  const reviewed = formatDate(reviewedAt);
 
   if (standalone) {
     return (
@@ -52,17 +60,17 @@ export function ApplicationStatusBanner({
         </CardHeader>
         <CardContent>
           <dl className='grid gap-2 text-sm sm:grid-cols-2'>
-            {submitted && (
-              <div>
-                <dt className='text-muted-foreground'>Submitted</dt>
-                <dd>{submitted}</dd>
-              </div>
-            )}
-            {reviewed && (
-              <div>
-                <dt className='text-muted-foreground'>Decision made</dt>
-                <dd>{reviewed}</dd>
-              </div>
+            {APPLICATION_TIMELINE_FIELDS.map(
+              ({ key, label: fieldLabel, getDate }) => {
+                const formatted = formatDate(getDate(timelineSource));
+                if (!formatted) return null;
+                return (
+                  <div key={key}>
+                    <dt className='text-muted-foreground'>{fieldLabel}</dt>
+                    <dd>{formatted}</dd>
+                  </div>
+                );
+              },
             )}
           </dl>
         </CardContent>
@@ -78,7 +86,9 @@ export function ApplicationStatusBanner({
       <div className='space-y-0.5 text-sm'>
         <p>{display.description}</p>
         {submitted && (
-          <p className='text-muted-foreground text-xs'>Submitted {submitted}</p>
+          <p className='text-muted-foreground text-xs'>
+            {APPLICATION_TIMELINE_LABELS.submitted} {submitted}
+          </p>
         )}
       </div>
     </div>

--- a/src/app/dashboard/events/ApplicationStatusBanner.tsx
+++ b/src/app/dashboard/events/ApplicationStatusBanner.tsx
@@ -33,9 +33,9 @@ export function ApplicationStatusBanner({
   application,
   standalone = false,
 }: Props) {
-  const { statusKey, waitlistPosition, createdAt, reviewedAt } = application;
+  const { statusKey, createdAt, reviewedAt } = application;
   const display = getApplicationStatusDisplay(statusKey);
-  const label = getApplicationStatusLabel(statusKey, waitlistPosition);
+  const label = getApplicationStatusLabel(statusKey);
   const timelineSource = { createdAt, reviewedAt };
   const submitted = formatDate(createdAt);
 

--- a/src/app/dashboard/events/ApplicationStatusBanner.tsx
+++ b/src/app/dashboard/events/ApplicationStatusBanner.tsx
@@ -1,0 +1,86 @@
+import { Badge } from '@/components/ui/badge';
+import {
+  Card,
+  CardContent,
+  CardDescription,
+  CardHeader,
+  CardTitle,
+} from '@/components/ui/card';
+import {
+  type ApplicationStatusLabel,
+  getApplicationStatusDisplay,
+  getApplicationStatusLabel,
+} from '@/app/dashboard/events/application-status';
+
+function formatDate(d: Date | null) {
+  if (!d) return null;
+  return new Intl.DateTimeFormat(undefined, {
+    dateStyle: 'medium',
+    timeStyle: 'short',
+  }).format(d);
+}
+
+type Props = {
+  statusKey: ApplicationStatusLabel | null;
+  waitlistPosition: number | null;
+  createdAt: Date;
+  reviewedAt: Date | null;
+  standalone?: boolean;
+};
+
+export function ApplicationStatusBanner({
+  statusKey,
+  waitlistPosition,
+  createdAt,
+  reviewedAt,
+  standalone = false,
+}: Props) {
+  const display = getApplicationStatusDisplay(statusKey);
+  const label = getApplicationStatusLabel(statusKey, waitlistPosition);
+  const submitted = formatDate(createdAt);
+  const reviewed = formatDate(reviewedAt);
+
+  if (standalone) {
+    return (
+      <Card className='w-full sm:max-w-2xl'>
+        <CardHeader>
+          <div className='flex items-center justify-between gap-2'>
+            <CardTitle>Application status</CardTitle>
+            <Badge variant={display.variant}>{label}</Badge>
+          </div>
+          <CardDescription>{display.description}</CardDescription>
+        </CardHeader>
+        <CardContent>
+          <dl className='grid gap-2 text-sm sm:grid-cols-2'>
+            {submitted && (
+              <div>
+                <dt className='text-muted-foreground'>Submitted</dt>
+                <dd>{submitted}</dd>
+              </div>
+            )}
+            {reviewed && (
+              <div>
+                <dt className='text-muted-foreground'>Decision made</dt>
+                <dd>{reviewed}</dd>
+              </div>
+            )}
+          </dl>
+        </CardContent>
+      </Card>
+    );
+  }
+
+  return (
+    <div className='bg-muted/40 flex items-start gap-3 rounded-lg border p-4'>
+      <Badge variant={display.variant} className='shrink-0'>
+        {label}
+      </Badge>
+      <div className='space-y-0.5 text-sm'>
+        <p>{display.description}</p>
+        {submitted && (
+          <p className='text-muted-foreground text-xs'>Submitted {submitted}</p>
+        )}
+      </div>
+    </div>
+  );
+}

--- a/src/app/dashboard/events/[eventId]/apply/page.tsx
+++ b/src/app/dashboard/events/[eventId]/apply/page.tsx
@@ -1,9 +1,11 @@
+import Link from 'next/link';
 import { redirect, notFound } from 'next/navigation';
 
 import { getUser } from '@/utils/auth';
 import {
   getOptions,
   getPreviousFormSubmission,
+  getUserApplicationStatus,
   submitEventApplication,
 } from '@/app/dashboard/events/actions';
 import {
@@ -20,10 +22,13 @@ import {
   CardHeader,
   CardTitle,
 } from '@/components/ui/card';
+import { Button } from '@/components/ui/button';
 import ProfileForm from '@/components/profile-form';
 import ApplicationForm from '@/components/application-form';
 import type { ProfileFormValues } from '@/components/profile-form/schema';
 import type { EventOnlyFormValues } from '@/components/application-form/schema';
+import { getApplicationStatusDisplay } from '@/app/dashboard/events/application-status';
+import { ApplicationStatusBanner } from '@/app/dashboard/events/ApplicationStatusBanner';
 
 type PreviousSubmission = {
   fullName: string;
@@ -103,11 +108,13 @@ export default async function ApplyEventPage({ params }: Props) {
     );
   }
 
-  const [previousApplication, options, profileResult] = await Promise.all([
-    getPreviousFormSubmission(eventId),
-    getOptions(),
-    getUserProfile(),
-  ]);
+  const [previousApplication, options, profileResult, applicationStatus] =
+    await Promise.all([
+      getPreviousFormSubmission(eventId),
+      getOptions(),
+      getUserProfile(),
+      getUserApplicationStatus(eventId),
+    ]);
 
   const hasProfile = profileResult.success && profileResult.data != null;
   const profileData = hasProfile ? profileResult.data : null;
@@ -123,6 +130,29 @@ export default async function ApplyEventPage({ params }: Props) {
     redirect(`/dashboard/profile?next=/dashboard/events/${eventId}/apply`);
   }
 
+  const decisionIsFinal =
+    applicationStatus != null &&
+    getApplicationStatusDisplay(applicationStatus.statusKey).isFinal;
+
+  if (decisionIsFinal && applicationStatus) {
+    return (
+      <div className='space-y-4'>
+        <ApplicationStatusBanner
+          statusKey={applicationStatus.statusKey}
+          waitlistPosition={applicationStatus.waitlistPosition}
+          createdAt={applicationStatus.createdAt}
+          reviewedAt={applicationStatus.reviewedAt}
+          standalone
+        />
+        <div className='sm:max-w-2xl'>
+          <Button asChild variant='outline' size='sm'>
+            <Link href='/dashboard/events'>← Back to events</Link>
+          </Button>
+        </div>
+      </div>
+    );
+  }
+
   return (
     <Card className='w-full sm:max-w-2xl'>
       <CardHeader>
@@ -132,6 +162,14 @@ export default async function ApplyEventPage({ params }: Props) {
         </CardDescription>
       </CardHeader>
       <CardContent className='space-y-8'>
+        {applicationStatus && (
+          <ApplicationStatusBanner
+            statusKey={applicationStatus.statusKey}
+            waitlistPosition={applicationStatus.waitlistPosition}
+            createdAt={applicationStatus.createdAt}
+            reviewedAt={applicationStatus.reviewedAt}
+          />
+        )}
         <section>
           <h3 className='mb-4 text-sm font-medium'>Your profile</h3>
           <ProfileForm

--- a/src/app/dashboard/events/[eventId]/apply/page.tsx
+++ b/src/app/dashboard/events/[eventId]/apply/page.tsx
@@ -27,7 +27,6 @@ import ProfileForm from '@/components/profile-form';
 import ApplicationForm from '@/components/application-form';
 import type { ProfileFormValues } from '@/components/profile-form/schema';
 import type { EventOnlyFormValues } from '@/components/application-form/schema';
-import { getApplicationStatusDisplay } from '@/app/dashboard/events/application-status';
 import { ApplicationStatusBanner } from '@/app/dashboard/events/ApplicationStatusBanner';
 
 type PreviousSubmission = {
@@ -131,8 +130,7 @@ export default async function ApplyEventPage({ params }: Props) {
   }
 
   const decisionIsFinal =
-    applicationStatus != null &&
-    getApplicationStatusDisplay(applicationStatus.statusKey).isFinal;
+    applicationStatus != null && applicationStatus.statusDisplay.isFinal;
 
   if (decisionIsFinal && applicationStatus) {
     return (

--- a/src/app/dashboard/events/[eventId]/apply/page.tsx
+++ b/src/app/dashboard/events/[eventId]/apply/page.tsx
@@ -137,13 +137,7 @@ export default async function ApplyEventPage({ params }: Props) {
   if (decisionIsFinal && applicationStatus) {
     return (
       <div className='space-y-4'>
-        <ApplicationStatusBanner
-          statusKey={applicationStatus.statusKey}
-          waitlistPosition={applicationStatus.waitlistPosition}
-          createdAt={applicationStatus.createdAt}
-          reviewedAt={applicationStatus.reviewedAt}
-          standalone
-        />
+        <ApplicationStatusBanner application={applicationStatus} standalone />
         <div className='sm:max-w-2xl'>
           <Button asChild variant='outline' size='sm'>
             <Link href='/dashboard/events'>← Back to events</Link>
@@ -163,12 +157,7 @@ export default async function ApplyEventPage({ params }: Props) {
       </CardHeader>
       <CardContent className='space-y-8'>
         {applicationStatus && (
-          <ApplicationStatusBanner
-            statusKey={applicationStatus.statusKey}
-            waitlistPosition={applicationStatus.waitlistPosition}
-            createdAt={applicationStatus.createdAt}
-            reviewedAt={applicationStatus.reviewedAt}
-          />
+          <ApplicationStatusBanner application={applicationStatus} />
         )}
         <section>
           <h3 className='mb-4 text-sm font-medium'>Your profile</h3>

--- a/src/app/dashboard/events/actions.ts
+++ b/src/app/dashboard/events/actions.ts
@@ -11,6 +11,7 @@ import {
   userInterests,
   userDietaryRestrictions,
   eventApplications,
+  applicationStatuses,
   eventAttendees,
   eventInterestRegistrations,
   applicationFormView,
@@ -248,6 +249,74 @@ export async function submitEventApplication(
     return fail('Complete your profile first before applying to events.');
 
   return registerParticipant(profile, eventData, eventId);
+}
+
+type ApplicationStatusLabel =
+  | 'pending_review'
+  | 'approved'
+  | 'denied'
+  | 'waitlisted';
+
+const APPLICATION_STATUS_DISPLAY: Record<ApplicationStatusLabel, string> = {
+  pending_review: 'Under review',
+  approved: 'Accepted',
+  denied: 'Not accepted',
+  waitlisted: 'On the waitlist',
+};
+export type ApplicationStatusForUser = {
+  applicationId: string;
+  statusKey: ApplicationStatusLabel | null;
+  statusTitle: string;
+  reviewedAt: Date | null;
+  waitlistPosition: number | null;
+  createdAt: Date;
+};
+function toStatusTitle(statusKey: string | null): string {
+  if (statusKey == null) {
+    return 'Application submitted';
+  }
+  const key = statusKey as ApplicationStatusLabel;
+  return APPLICATION_STATUS_DISPLAY[key] ?? statusKey.replaceAll('_', ' ');
+}
+
+/**
+ * Current user's application row for an event + review status label.
+ * Returns null if there is no application row for (user, event).
+ */
+export async function getUserApplicationStatus(
+  eventId: string,
+): Promise<ApplicationStatusForUser | null> {
+  const user = await getUser();
+  if (!user) return null;
+  const [row] = await db
+    .select({
+      applicationId: eventApplications.id,
+      statusKey: applicationStatuses.label,
+      reviewedAt: eventApplications.reviewedAt,
+      waitlistPosition: eventApplications.waitlistPosition,
+      createdAt: eventApplications.createdAt,
+    })
+    .from(eventApplications)
+    .leftJoin(
+      applicationStatuses,
+      eq(eventApplications.statusId, applicationStatuses.id),
+    )
+    .where(
+      and(
+        eq(eventApplications.userId, user.id),
+        eq(eventApplications.eventId, eventId),
+      ),
+    )
+    .limit(1);
+  if (!row) return null;
+  return {
+    applicationId: row.applicationId,
+    statusKey: row.statusKey as ApplicationStatusLabel | null,
+    statusTitle: toStatusTitle(row.statusKey),
+    reviewedAt: row.reviewedAt,
+    waitlistPosition: row.waitlistPosition,
+    createdAt: row.createdAt,
+  };
 }
 
 /**

--- a/src/app/dashboard/events/actions.ts
+++ b/src/app/dashboard/events/actions.ts
@@ -42,6 +42,10 @@ import {
   buildApplicationResponses,
   fromResponseKeys,
 } from './application-responses';
+import {
+  type ApplicationStatusLabel,
+  getApplicationStatusDisplay,
+} from './application-status';
 
 /**
  * Returns the first event with has_application = true (e.g. default hackathon).
@@ -251,18 +255,6 @@ export async function submitEventApplication(
   return registerParticipant(profile, eventData, eventId);
 }
 
-type ApplicationStatusLabel =
-  | 'pending_review'
-  | 'approved'
-  | 'denied'
-  | 'waitlisted';
-
-const APPLICATION_STATUS_DISPLAY: Record<ApplicationStatusLabel, string> = {
-  pending_review: 'Under review',
-  approved: 'Accepted',
-  denied: 'Not accepted',
-  waitlisted: 'On the waitlist',
-};
 export type ApplicationStatusForUser = {
   applicationId: string;
   statusKey: ApplicationStatusLabel | null;
@@ -271,13 +263,6 @@ export type ApplicationStatusForUser = {
   waitlistPosition: number | null;
   createdAt: Date;
 };
-function toStatusTitle(statusKey: string | null): string {
-  if (statusKey == null) {
-    return 'Application submitted';
-  }
-  const key = statusKey as ApplicationStatusLabel;
-  return APPLICATION_STATUS_DISPLAY[key] ?? statusKey.replaceAll('_', ' ');
-}
 
 /**
  * Current user's application row for an event + review status label.
@@ -309,10 +294,11 @@ export async function getUserApplicationStatus(
     )
     .limit(1);
   if (!row) return null;
+  const statusKey = row.statusKey as ApplicationStatusLabel | null;
   return {
     applicationId: row.applicationId,
-    statusKey: row.statusKey as ApplicationStatusLabel | null,
-    statusTitle: toStatusTitle(row.statusKey),
+    statusKey,
+    statusTitle: getApplicationStatusDisplay(statusKey).title,
     reviewedAt: row.reviewedAt,
     waitlistPosition: row.waitlistPosition,
     createdAt: row.createdAt,
@@ -363,6 +349,8 @@ export type EventWithUserStatus = {
   startsAt: Date | null;
   endsAt: Date | null;
   userStatus: 'applied' | 'registered' | null;
+  statusKey: ApplicationStatusLabel | null;
+  waitlistPosition: number | null;
 };
 
 /**
@@ -395,10 +383,18 @@ export async function getEventsWithUserStatus(): Promise<
     )
     .orderBy(desc(events.createdAt));
 
-  const [applicationEventIds, attendeeEventIds] = await Promise.all([
+  const [applicationRows, attendeeEventIds] = await Promise.all([
     db
-      .select({ eventId: eventApplications.eventId })
+      .select({
+        eventId: eventApplications.eventId,
+        statusKey: applicationStatuses.label,
+        waitlistPosition: eventApplications.waitlistPosition,
+      })
       .from(eventApplications)
+      .leftJoin(
+        applicationStatuses,
+        eq(eventApplications.statusId, applicationStatuses.id),
+      )
       .where(eq(eventApplications.userId, user.id)),
     db
       .select({ eventId: eventAttendees.eventId })
@@ -406,22 +402,30 @@ export async function getEventsWithUserStatus(): Promise<
       .where(eq(eventAttendees.userId, user.id)),
   ]);
 
-  const appliedSet = new Set(applicationEventIds.map((r) => r.eventId));
   const registeredSet = new Set(attendeeEventIds.map((r) => r.eventId));
+  const statusByEventId = new Map(
+    applicationRows.map((r) => [r.eventId, r] as const),
+  );
 
-  return allEvents.map((e) => ({
-    id: e.id,
-    name: e.name,
-    hasApplication: e.hasApplication,
-    userHasRegisteredInterest: Boolean(e.userHasRegisteredInterest),
-    startsAt: e.startsAt,
-    endsAt: e.endsAt,
-    userStatus: e.hasApplication
-      ? appliedSet.has(e.id)
-        ? ('applied' as const)
-        : null
-      : registeredSet.has(e.id)
-        ? ('registered' as const)
-        : null,
-  }));
+  return allEvents.map((e) => {
+    const application = statusByEventId.get(e.id);
+    return {
+      id: e.id,
+      name: e.name,
+      hasApplication: e.hasApplication,
+      userHasRegisteredInterest: Boolean(e.userHasRegisteredInterest),
+      startsAt: e.startsAt,
+      endsAt: e.endsAt,
+      userStatus: e.hasApplication
+        ? statusByEventId.has(e.id)
+          ? ('applied' as const)
+          : null
+        : registeredSet.has(e.id)
+          ? ('registered' as const)
+          : null,
+      statusKey:
+        (application?.statusKey ?? null) as ApplicationStatusLabel | null,
+      waitlistPosition: application?.waitlistPosition ?? null,
+    };
+  });
 }

--- a/src/app/dashboard/events/actions.ts
+++ b/src/app/dashboard/events/actions.ts
@@ -45,6 +45,7 @@ import {
 import {
   type ApplicationStatusLabel,
   getApplicationStatusDisplay,
+  resolveApplicationStatusKey,
 } from './application-status';
 
 /**
@@ -100,6 +101,15 @@ export async function registerParticipant(
   if (!built.ok) return fail(built.error);
   const responses = built.responses;
 
+  const [pendingReview] = await db
+    .select({ id: applicationStatuses.id })
+    .from(applicationStatuses)
+    .where(eq(applicationStatuses.label, 'pending_review'))
+    .limit(1);
+  if (!pendingReview) {
+    return fail('Application statuses are not configured.');
+  }
+
   try {
     await db.transaction(async (tx) => {
       await tx
@@ -152,6 +162,7 @@ export async function registerParticipant(
           eventId,
           userId: user.id,
           responses,
+          statusId: pendingReview.id,
         })
         .onConflictDoUpdate({
           target: [eventApplications.eventId, eventApplications.userId],
@@ -257,7 +268,7 @@ export async function submitEventApplication(
 
 export type ApplicationStatusForUser = {
   applicationId: string;
-  statusKey: ApplicationStatusLabel | null;
+  statusKey: ApplicationStatusLabel;
   statusTitle: string;
   reviewedAt: Date | null;
   waitlistPosition: number | null;
@@ -294,7 +305,7 @@ export async function getUserApplicationStatus(
     )
     .limit(1);
   if (!row) return null;
-  const statusKey = row.statusKey as ApplicationStatusLabel | null;
+  const statusKey = resolveApplicationStatusKey(row.statusKey);
   return {
     applicationId: row.applicationId,
     statusKey,
@@ -370,12 +381,11 @@ export async function getEventsWithUserStatus(): Promise<
       hasApplication: events.hasApplication,
       startsAt: events.startsAt,
       endsAt: events.endsAt,
-      userHasRegisteredInterest: isNotNull(
-        eventInterestRegistrations.userId,
-      ),
+      userHasRegisteredInterest: isNotNull(eventInterestRegistrations.userId),
     })
     .from(events)
-    .leftJoin(eventInterestRegistrations,
+    .leftJoin(
+      eventInterestRegistrations,
       and(
         eq(eventInterestRegistrations.eventId, events.id),
         eq(eventInterestRegistrations.userId, user.id),
@@ -423,8 +433,9 @@ export async function getEventsWithUserStatus(): Promise<
         : registeredSet.has(e.id)
           ? ('registered' as const)
           : null,
-      statusKey:
-        (application?.statusKey ?? null) as ApplicationStatusLabel | null,
+      statusKey: application
+        ? resolveApplicationStatusKey(application.statusKey)
+        : null,
       waitlistPosition: application?.waitlistPosition ?? null,
     };
   });

--- a/src/app/dashboard/events/actions.ts
+++ b/src/app/dashboard/events/actions.ts
@@ -44,7 +44,9 @@ import {
 } from './application-responses';
 import {
   type ApplicationStatusLabel,
+  type ApplicationStatusDisplay,
   getApplicationStatusDisplay,
+  getApplicationStatusDisplayMap,
   resolveApplicationStatusKey,
 } from './application-status';
 
@@ -269,7 +271,7 @@ export async function submitEventApplication(
 export type ApplicationStatusForUser = {
   applicationId: string;
   statusKey: ApplicationStatusLabel;
-  statusTitle: string;
+  statusDisplay: ApplicationStatusDisplay;
   reviewedAt: Date | null;
   waitlistPosition: number | null;
   createdAt: Date;
@@ -309,7 +311,7 @@ export async function getUserApplicationStatus(
   return {
     ...row,
     statusKey,
-    statusTitle: getApplicationStatusDisplay(statusKey).title,
+    statusDisplay: await getApplicationStatusDisplay(statusKey),
   };
 }
 
@@ -358,6 +360,7 @@ export type EventWithUserStatus = {
   endsAt: Date | null;
   userStatus: 'applied' | 'registered' | null;
   statusKey: ApplicationStatusLabel | null;
+  statusDisplay: ApplicationStatusDisplay | null;
   waitlistPosition: number | null;
 };
 
@@ -413,9 +416,13 @@ export async function getEventsWithUserStatus(): Promise<
   const statusByEventId = new Map(
     applicationRows.map((r) => [r.eventId, r] as const),
   );
+  const displayMap = await getApplicationStatusDisplayMap();
 
   return allEvents.map((e) => {
     const application = statusByEventId.get(e.id);
+    const statusKey = application
+      ? resolveApplicationStatusKey(application.statusKey)
+      : null;
     return {
       id: e.id,
       name: e.name,
@@ -430,9 +437,8 @@ export async function getEventsWithUserStatus(): Promise<
         : registeredSet.has(e.id)
           ? ('registered' as const)
           : null,
-      statusKey: application
-        ? resolveApplicationStatusKey(application.statusKey)
-        : null,
+      statusKey,
+      statusDisplay: statusKey ? displayMap[statusKey] : null,
       waitlistPosition: application?.waitlistPosition ?? null,
     };
   });

--- a/src/app/dashboard/events/actions.ts
+++ b/src/app/dashboard/events/actions.ts
@@ -307,12 +307,9 @@ export async function getUserApplicationStatus(
   if (!row) return null;
   const statusKey = resolveApplicationStatusKey(row.statusKey);
   return {
-    applicationId: row.applicationId,
+    ...row,
     statusKey,
     statusTitle: getApplicationStatusDisplay(statusKey).title,
-    reviewedAt: row.reviewedAt,
-    waitlistPosition: row.waitlistPosition,
-    createdAt: row.createdAt,
   };
 }
 

--- a/src/app/dashboard/events/application-status.ts
+++ b/src/app/dashboard/events/application-status.ts
@@ -9,6 +9,9 @@ export type ApplicationStatusLabel =
   | 'denied'
   | 'waitlisted';
 
+export const DEFAULT_APPLICATION_STATUS: ApplicationStatusLabel =
+  'pending_review';
+
 export type ApplicationStatusBadgeVariant =
   | 'default'
   | 'secondary'
@@ -40,8 +43,7 @@ const DISPLAY: Record<ApplicationStatusLabel, ApplicationStatusDisplay> = {
   },
   waitlisted: {
     title: 'Waitlisted',
-    description:
-      "You're on the waitlist. We'll reach out if a spot opens up.",
+    description: "You're on the waitlist. We'll reach out if a spot opens up.",
     variant: 'secondary',
     isFinal: true,
   },
@@ -54,31 +56,56 @@ const DISPLAY: Record<ApplicationStatusLabel, ApplicationStatusDisplay> = {
   },
 };
 
-const SUBMITTED_FALLBACK: ApplicationStatusDisplay = {
-  title: 'Application submitted',
-  description:
-    "Your application has been received. We'll email you when a decision has been made.",
-  variant: 'outline',
-  isFinal: false,
-};
+/** Normalize DB label, null -> pending_review. */
+export function resolveApplicationStatusKey(
+  statusKey: string | null | undefined,
+): ApplicationStatusLabel {
+  if (statusKey && statusKey in DISPLAY) {
+    return statusKey as ApplicationStatusLabel;
+  }
+  return DEFAULT_APPLICATION_STATUS;
+}
 
-/** Display config for a status label; null/unknown → submitted, not yet triaged. */
+/** Display config for a status label, null -> pending_review. */
 export function getApplicationStatusDisplay(
   statusKey: ApplicationStatusLabel | null | undefined,
 ): ApplicationStatusDisplay {
-  if (statusKey && statusKey in DISPLAY) {
-    return DISPLAY[statusKey];
-  }
-  return SUBMITTED_FALLBACK;
+  return DISPLAY[resolveApplicationStatusKey(statusKey)];
 }
+
+/** Labels for application timeline fields shown in the status banner. */
+export const APPLICATION_TIMELINE_LABELS = {
+  submitted: 'Submitted',
+  decisionMade: 'Decision made',
+} as const;
+
+type ApplicationTimelineSource = {
+  createdAt: Date;
+  reviewedAt: Date | null;
+};
+
+/** Timeline fields rendered in the status card (label + date source). */
+export const APPLICATION_TIMELINE_FIELDS = [
+  {
+    key: 'submitted',
+    label: APPLICATION_TIMELINE_LABELS.submitted,
+    getDate: (source: ApplicationTimelineSource) => source.createdAt,
+  },
+  {
+    key: 'decisionMade',
+    label: APPLICATION_TIMELINE_LABELS.decisionMade,
+    getDate: (source: ApplicationTimelineSource) => source.reviewedAt,
+  },
+] as const;
 
 /** Status title for badges; appends waitlist position when waitlisted. */
 export function getApplicationStatusLabel(
   statusKey: ApplicationStatusLabel | null | undefined,
   waitlistPosition: number | null | undefined,
 ): string {
-  const display = getApplicationStatusDisplay(statusKey);
-  if (statusKey === 'waitlisted' && waitlistPosition != null) {
+  const resolved = resolveApplicationStatusKey(statusKey);
+  const display = getApplicationStatusDisplay(resolved);
+  if (resolved === 'waitlisted' && waitlistPosition != null) {
     return `${display.title} #${waitlistPosition}`;
   }
   return display.title;

--- a/src/app/dashboard/events/application-status.ts
+++ b/src/app/dashboard/events/application-status.ts
@@ -1,24 +1,25 @@
 /**
  * UI labels and badge variants for application_statuses (pending_review, approved,
- * denied, waitlisted). Used by events list and apply page.
+ * denied, waitlisted). The display config (title/description/variant/is_final)
+ * lives in the application_statuses table and is read on the server.
  */
 
-export type ApplicationStatusLabel =
-  | 'pending_review'
-  | 'approved'
-  | 'denied'
-  | 'waitlisted';
+import 'server-only';
+import { cache } from 'react';
+
+import { db } from '@/utils/db';
+import { applicationStatuses } from '@/db/schema';
+import {
+  applicationStatusesList,
+  type ApplicationStatus,
+  type ApplicationStatusBadgeVariant,
+} from '@/types/lookups';
+
+export type ApplicationStatusLabel = ApplicationStatus;
+export type { ApplicationStatusBadgeVariant };
 
 export const DEFAULT_APPLICATION_STATUS: ApplicationStatusLabel =
   'pending_review';
-
-export type ApplicationStatusBadgeVariant =
-  | 'default'
-  | 'secondary'
-  | 'success'
-  | 'warning'
-  | 'destructive'
-  | 'outline';
 
 export type ApplicationStatusDisplay = {
   title: string;
@@ -27,50 +28,53 @@ export type ApplicationStatusDisplay = {
   isFinal: boolean;
 };
 
-const DISPLAY: Record<ApplicationStatusLabel, ApplicationStatusDisplay> = {
-  pending_review: {
-    title: 'Under review',
-    description:
-      "We're reviewing your application and will email you when a decision has been made.",
-    variant: 'warning',
-    isFinal: false,
-  },
-  approved: {
-    title: 'Accepted',
-    description: "You're in! Check your email and ticket for next steps.",
-    variant: 'success',
-    isFinal: true,
-  },
-  waitlisted: {
-    title: 'Waitlisted',
-    description: "You're on the waitlist. We'll reach out if a spot opens up.",
-    variant: 'secondary',
-    isFinal: true,
-  },
-  denied: {
-    title: 'Not accepted',
-    description:
-      'Thanks for applying — unfortunately we were not able to offer you a spot.',
-    variant: 'destructive',
-    isFinal: true,
-  },
-};
+const VALID_STATUS_LABELS: readonly string[] = applicationStatusesList;
 
 /** Normalize DB label, null -> pending_review. */
 export function resolveApplicationStatusKey(
   statusKey: string | null | undefined,
 ): ApplicationStatusLabel {
-  if (statusKey && statusKey in DISPLAY) {
+  if (statusKey && VALID_STATUS_LABELS.includes(statusKey)) {
     return statusKey as ApplicationStatusLabel;
   }
   return DEFAULT_APPLICATION_STATUS;
 }
 
-/** Display config for a status label, null -> pending_review. */
-export function getApplicationStatusDisplay(
+/**
+ * Reads all application_statuses display rows and returns them keyed by label.
+ * Cached per request so callers can resolve many statuses with one query.
+ */
+export const getApplicationStatusDisplayMap = cache(
+  async (): Promise<Record<ApplicationStatusLabel, ApplicationStatusDisplay>> => {
+    const rows = await db
+      .select({
+        label: applicationStatuses.label,
+        title: applicationStatuses.title,
+        description: applicationStatuses.description,
+        variant: applicationStatuses.variant,
+        isFinal: applicationStatuses.isFinal,
+      })
+      .from(applicationStatuses);
+
+    const map = {} as Record<ApplicationStatusLabel, ApplicationStatusDisplay>;
+    for (const row of rows) {
+      map[resolveApplicationStatusKey(row.label)] = {
+        title: row.title,
+        description: row.description,
+        variant: row.variant as ApplicationStatusBadgeVariant,
+        isFinal: row.isFinal,
+      };
+    }
+    return map;
+  },
+);
+
+/** Display config for a single status label, null -> pending_review. */
+export async function getApplicationStatusDisplay(
   statusKey: ApplicationStatusLabel | null | undefined,
-): ApplicationStatusDisplay {
-  return DISPLAY[resolveApplicationStatusKey(statusKey)];
+): Promise<ApplicationStatusDisplay> {
+  const map = await getApplicationStatusDisplayMap();
+  return map[resolveApplicationStatusKey(statusKey)];
 }
 
 /** Labels for application timeline fields shown in the status banner. */
@@ -97,12 +101,3 @@ export const APPLICATION_TIMELINE_FIELDS = [
     getDate: (source: ApplicationTimelineSource) => source.reviewedAt,
   },
 ] as const;
-
-/** Status title for badges. */
-export function getApplicationStatusLabel(
-  statusKey: ApplicationStatusLabel | null | undefined,
-): string {
-  const resolved = resolveApplicationStatusKey(statusKey);
-  const display = getApplicationStatusDisplay(resolved);
-  return display.title;
-}

--- a/src/app/dashboard/events/application-status.ts
+++ b/src/app/dashboard/events/application-status.ts
@@ -98,15 +98,11 @@ export const APPLICATION_TIMELINE_FIELDS = [
   },
 ] as const;
 
-/** Status title for badges; appends waitlist position when waitlisted. */
+/** Status title for badges. */
 export function getApplicationStatusLabel(
   statusKey: ApplicationStatusLabel | null | undefined,
-  waitlistPosition: number | null | undefined,
 ): string {
   const resolved = resolveApplicationStatusKey(statusKey);
   const display = getApplicationStatusDisplay(resolved);
-  if (resolved === 'waitlisted' && waitlistPosition != null) {
-    return `${display.title} #${waitlistPosition}`;
-  }
   return display.title;
 }

--- a/src/app/dashboard/events/application-status.ts
+++ b/src/app/dashboard/events/application-status.ts
@@ -1,0 +1,85 @@
+/**
+ * UI labels and badge variants for application_statuses (pending_review, approved,
+ * denied, waitlisted). Used by events list and apply page.
+ */
+
+export type ApplicationStatusLabel =
+  | 'pending_review'
+  | 'approved'
+  | 'denied'
+  | 'waitlisted';
+
+export type ApplicationStatusBadgeVariant =
+  | 'default'
+  | 'secondary'
+  | 'success'
+  | 'warning'
+  | 'destructive'
+  | 'outline';
+
+export type ApplicationStatusDisplay = {
+  title: string;
+  description: string;
+  variant: ApplicationStatusBadgeVariant;
+  isFinal: boolean;
+};
+
+const DISPLAY: Record<ApplicationStatusLabel, ApplicationStatusDisplay> = {
+  pending_review: {
+    title: 'Under review',
+    description:
+      "We're reviewing your application and will email you when a decision has been made.",
+    variant: 'warning',
+    isFinal: false,
+  },
+  approved: {
+    title: 'Accepted',
+    description: "You're in! Check your email and ticket for next steps.",
+    variant: 'success',
+    isFinal: true,
+  },
+  waitlisted: {
+    title: 'Waitlisted',
+    description:
+      "You're on the waitlist. We'll reach out if a spot opens up.",
+    variant: 'secondary',
+    isFinal: true,
+  },
+  denied: {
+    title: 'Not accepted',
+    description:
+      'Thanks for applying — unfortunately we were not able to offer you a spot.',
+    variant: 'destructive',
+    isFinal: true,
+  },
+};
+
+const SUBMITTED_FALLBACK: ApplicationStatusDisplay = {
+  title: 'Application submitted',
+  description:
+    "Your application has been received. We'll email you when a decision has been made.",
+  variant: 'outline',
+  isFinal: false,
+};
+
+/** Display config for a status label; null/unknown → submitted, not yet triaged. */
+export function getApplicationStatusDisplay(
+  statusKey: ApplicationStatusLabel | null | undefined,
+): ApplicationStatusDisplay {
+  if (statusKey && statusKey in DISPLAY) {
+    return DISPLAY[statusKey];
+  }
+  return SUBMITTED_FALLBACK;
+}
+
+/** Status title for badges; appends waitlist position when waitlisted. */
+export function getApplicationStatusLabel(
+  statusKey: ApplicationStatusLabel | null | undefined,
+  waitlistPosition: number | null | undefined,
+): string {
+  const display = getApplicationStatusDisplay(statusKey);
+  if (statusKey === 'waitlisted' && waitlistPosition != null) {
+    return `${display.title} #${waitlistPosition}`;
+  }
+  return display.title;
+}

--- a/src/app/dashboard/events/page.tsx
+++ b/src/app/dashboard/events/page.tsx
@@ -17,11 +17,7 @@ import { RegisterEventButton } from './RegisterEventButton';
 import { UnregisterEventButton } from './UnregisterEventButton';
 import { RegisterEventInterestButton } from './RegisterEventInterestButton';
 import { Calendar } from 'lucide-react';
-import {
-  type ApplicationStatusLabel,
-  getApplicationStatusDisplay,
-  getApplicationStatusLabel,
-} from '@/app/dashboard/events/application-status';
+import type { ApplicationStatusLabel } from '@/app/dashboard/events/application-status';
 
 function formatDate(d: Date | null) {
   if (!d) return null;
@@ -86,15 +82,13 @@ export default async function DashboardEventsPage() {
                 <CardHeader className='pb-2'>
                   <div className='flex items-start justify-between gap-2'>
                     <CardTitle className='text-lg'>{event.name}</CardTitle>
-                    {event.hasApplication && event.userStatus === 'applied' && (
-                      <Badge
-                        variant={
-                          getApplicationStatusDisplay(event.statusKey).variant
-                        }
-                      >
-                        {getApplicationStatusLabel(event.statusKey)}
-                      </Badge>
-                    )}
+                    {event.hasApplication &&
+                      event.userStatus === 'applied' &&
+                      event.statusDisplay && (
+                        <Badge variant={event.statusDisplay.variant}>
+                          {event.statusDisplay.title}
+                        </Badge>
+                      )}
                   </div>
                   <CardDescription className='text-sm'>
                     {event.startsAt && (

--- a/src/app/dashboard/events/page.tsx
+++ b/src/app/dashboard/events/page.tsx
@@ -12,10 +12,16 @@ import {
   CardTitle,
 } from '@/components/ui/card';
 import { Button } from '@/components/ui/button';
+import { Badge } from '@/components/ui/badge';
 import { RegisterEventButton } from './RegisterEventButton';
 import { UnregisterEventButton } from './UnregisterEventButton';
 import { RegisterEventInterestButton } from './RegisterEventInterestButton';
 import { Calendar } from 'lucide-react';
+import {
+  type ApplicationStatusLabel,
+  getApplicationStatusDisplay,
+  getApplicationStatusLabel,
+} from '@/app/dashboard/events/application-status';
 
 function formatDate(d: Date | null) {
   if (!d) return null;
@@ -23,6 +29,16 @@ function formatDate(d: Date | null) {
     dateStyle: 'medium',
     timeStyle: 'short',
   }).format(d);
+}
+
+function applyCtaLabel(
+  hasApplied: boolean,
+  statusKey: ApplicationStatusLabel | null,
+): string {
+  if (!hasApplied) return 'Apply';
+  const display = getApplicationStatusDisplay(statusKey);
+  if (display.isFinal) return 'View status';
+  return 'Edit application';
 }
 
 export default async function DashboardEventsPage() {
@@ -62,7 +78,21 @@ export default async function DashboardEventsPage() {
             <li key={event.id}>
               <Card className='flex h-full flex-col'>
                 <CardHeader className='pb-2'>
-                  <CardTitle className='text-lg'>{event.name}</CardTitle>
+                  <div className='flex items-start justify-between gap-2'>
+                    <CardTitle className='text-lg'>{event.name}</CardTitle>
+                    {event.hasApplication && event.userStatus === 'applied' && (
+                      <Badge
+                        variant={
+                          getApplicationStatusDisplay(event.statusKey).variant
+                        }
+                      >
+                        {getApplicationStatusLabel(
+                          event.statusKey,
+                          event.waitlistPosition,
+                        )}
+                      </Badge>
+                    )}
+                  </div>
                   <CardDescription className='text-sm'>
                     {event.startsAt && (
                       <span>
@@ -77,9 +107,10 @@ export default async function DashboardEventsPage() {
                   {event.hasApplication ? (
                     <Button asChild size='sm' variant='default'>
                       <Link href={`/dashboard/events/${event.id}/apply`}>
-                        {event.userStatus === 'applied'
-                          ? 'Edit application'
-                          : 'Apply'}
+                        {applyCtaLabel(
+                          event.userStatus === 'applied',
+                          event.statusKey,
+                        )}
                       </Link>
                     </Button>
                   ) : (

--- a/src/app/dashboard/events/page.tsx
+++ b/src/app/dashboard/events/page.tsx
@@ -36,9 +36,16 @@ function applyCtaLabel(
   statusKey: ApplicationStatusLabel | null,
 ): string {
   if (!hasApplied) return 'Apply';
-  const display = getApplicationStatusDisplay(statusKey);
-  if (display.isFinal) return 'View status';
-  return 'Edit application';
+
+  switch (statusKey) {
+    case 'approved':
+    case 'denied':
+    case 'waitlisted':
+      return 'View status';
+    case 'pending_review':
+    default:
+      return 'Edit application';
+  }
 }
 
 export default async function DashboardEventsPage() {
@@ -85,10 +92,7 @@ export default async function DashboardEventsPage() {
                           getApplicationStatusDisplay(event.statusKey).variant
                         }
                       >
-                        {getApplicationStatusLabel(
-                          event.statusKey,
-                          event.waitlistPosition,
-                        )}
+                        {getApplicationStatusLabel(event.statusKey)}
                       </Badge>
                     )}
                   </div>

--- a/src/app/dashboard/events/page.tsx
+++ b/src/app/dashboard/events/page.tsx
@@ -48,8 +48,7 @@ export default async function DashboardEventsPage() {
   const eventsList = await getEventsWithUserStatus();
 
   const profileResult = await getUserProfile();
-  const hasProfile =
-    profileResult.success && profileResult.data != null;
+  const hasProfile = profileResult.success && profileResult.data != null;
 
   return (
     <div className='space-y-6'>

--- a/src/components/ui/badge.tsx
+++ b/src/components/ui/badge.tsx
@@ -1,0 +1,50 @@
+import * as React from 'react';
+import { Slot } from '@radix-ui/react-slot';
+import { cva, type VariantProps } from 'class-variance-authority';
+
+import { cn } from '@/lib/utils';
+
+const badgeVariants = cva(
+  'inline-flex items-center justify-center gap-1 rounded-full border px-2 py-0.5 text-xs font-medium whitespace-nowrap w-fit shrink-0 [&>svg]:pointer-events-none [&>svg]:size-3 transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring/50',
+  {
+    variants: {
+      variant: {
+        default:
+          'border-transparent bg-primary text-primary-foreground [a&]:hover:bg-primary/90',
+        secondary:
+          'border-transparent bg-secondary text-secondary-foreground [a&]:hover:bg-secondary/90',
+        destructive:
+          'border-transparent bg-destructive/10 text-destructive dark:bg-destructive/20 dark:text-destructive-foreground',
+        success:
+          'border-transparent bg-emerald-100 text-emerald-900 dark:bg-emerald-900/30 dark:text-emerald-200',
+        warning:
+          'border-transparent bg-amber-100 text-amber-900 dark:bg-amber-900/30 dark:text-amber-200',
+        outline:
+          'text-foreground border-border [a&]:hover:bg-accent [a&]:hover:text-accent-foreground',
+      },
+    },
+    defaultVariants: {
+      variant: 'default',
+    },
+  },
+);
+
+function Badge({
+  className,
+  variant,
+  asChild = false,
+  ...props
+}: React.ComponentProps<'span'> &
+  VariantProps<typeof badgeVariants> & { asChild?: boolean }) {
+  const Comp = asChild ? Slot : 'span';
+
+  return (
+    <Comp
+      data-slot='badge'
+      className={cn(badgeVariants({ variant }), className)}
+      {...props}
+    />
+  );
+}
+
+export { Badge, badgeVariants };

--- a/src/db/lookups.ts
+++ b/src/db/lookups.ts
@@ -11,7 +11,7 @@
  * - label: Unique, human-readable string value
  */
 
-import { pgTable, serial, varchar } from 'drizzle-orm/pg-core';
+import { pgTable, serial, varchar, boolean } from 'drizzle-orm/pg-core';
 
 /**
  * Gender options for participant profile and application form
@@ -97,10 +97,17 @@ export const heardFromSources = pgTable('heard_from_sources', {
  * Application status (manual review outcome)
  *
  * Values: pending_review, approved, denied, waitlisted.
+ *
+ * Display columns (title, description, variant, is_final) drive the UI badge
+ * and status banner shown to applicants.
  */
 export const applicationStatuses = pgTable('application_statuses', {
   id: serial('id').primaryKey(),
   label: varchar('label', { length: 50 }).unique().notNull(),
+  title: varchar('title', { length: 100 }).notNull(),
+  description: varchar('description', { length: 500 }).notNull(),
+  variant: varchar('variant', { length: 20 }).notNull(),
+  isFinal: boolean('is_final').notNull(),
 });
 
 /**

--- a/src/types/lookups.ts
+++ b/src/types/lookups.ts
@@ -79,6 +79,57 @@ export const applicationStatusesList = [
 ] as const;
 export type ApplicationStatus = (typeof applicationStatusesList)[number];
 
+export type ApplicationStatusBadgeVariant =
+  | 'default'
+  | 'secondary'
+  | 'success'
+  | 'warning'
+  | 'destructive'
+  | 'outline';
+
+/**
+ * Display config for each application status, seeded into the
+ * `application_statuses` table (title, description, badge variant, isFinal).
+ */
+export const applicationStatusDisplayList = [
+  {
+    label: 'pending_review',
+    title: 'Under review',
+    description:
+      "We're reviewing your application and will email you when a decision has been made.",
+    variant: 'warning',
+    isFinal: false,
+  },
+  {
+    label: 'approved',
+    title: 'Accepted',
+    description: "You're in! Check your email and ticket for next steps.",
+    variant: 'success',
+    isFinal: true,
+  },
+  {
+    label: 'waitlisted',
+    title: 'Waitlisted',
+    description: "You're on the waitlist. We'll reach out if a spot opens up.",
+    variant: 'secondary',
+    isFinal: true,
+  },
+  {
+    label: 'denied',
+    title: 'Not accepted',
+    description:
+      'Thanks for applying — unfortunately we were not able to offer you a spot.',
+    variant: 'destructive',
+    isFinal: true,
+  },
+] as const satisfies readonly {
+  label: ApplicationStatus;
+  title: string;
+  description: string;
+  variant: ApplicationStatusBadgeVariant;
+  isFinal: boolean;
+}[];
+
 export const rsvpStatusesList = [
   'pending',
   'accepted',


### PR DESCRIPTION
Adds application status to events.

What changed:
- Added getUserApplicationStatus and extended getEventsWithUserStatus with review status
- Added status badges on event cards and banner on apply page
- Apply form is read-only after a final decision

Behavior:
- Pending → badge + editable form
- Approved / denied / waitlisted → status card only

Tested:
- Status badges update when status_id is changed in DB
- Final statuses hide the apply form